### PR TITLE
Some CSS changes regarding overflow and minor code changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "frontend",
+  "name": "distrohopper-wheel",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend",
+      "name": "distrohopper-wheel",
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "distrohopper-wheel",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Home from './pages/Home';
 import './styles/App.css';
 

--- a/src/components/Wheel.jsx
+++ b/src/components/Wheel.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Wheel } from "react-custom-roulette";
 import { Button } from 'react95';
 import segments from "../data/segments";
 import easyModeSegments from "../data/easyModeSegments";
 import superEasyModeSegments from "../data/superEasyModeSegments";
 import '../styles/Wheel.css';
+import PropTypes from 'prop-types';
 
 const WheelComponent = ({ setResult, easyMode, superEasyMode }) => {
   const [mustSpin, setMustSpin] = useState(false);
@@ -48,5 +49,12 @@ const WheelComponent = ({ setResult, easyMode, superEasyMode }) => {
     </div>
   );
 };
+
+// Prop Validation
+WheelComponent.propTypes = {
+  setResult: PropTypes.func.isRequired,
+  easyMode: PropTypes.bool,
+  superEasyMode: PropTypes.bool
+}
 
 export default WheelComponent;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { AppBar, Toolbar, Button, Window, WindowHeader, WindowContent, styleReset, MenuList, MenuListItem, Checkbox } from 'react95';
 import { createGlobalStyle, ThemeProvider } from 'styled-components';
 import original from 'react95/dist/themes/original';
@@ -26,15 +26,6 @@ const GlobalStyles = createGlobalStyle`
   }
   body, input, select, textarea {
     font-family: 'ms_sans_serif';
-  }
-  html, body, #root {
-    height: 100%;
-    margin: 0;
-    overflow: hidden; /* Prevent overflow */
-  }
-  #root {
-    display: flex;
-    flex-direction: column;
   }
 `;
 
@@ -74,7 +65,7 @@ const Home = () => {
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+    <>
       <GlobalStyles />
       <ThemeProvider theme={original}>
         <AppBar className="app-bar">
@@ -127,7 +118,7 @@ const Home = () => {
         </AppBar>
         <Window className="window">
           <WindowHeader className="window-header">
-            <span>The amazing DistroHopper Wheel of Fortune! May the force be with you.</span>
+            The amazing DistroHopper Wheel of Fortune! May the force be with you.
           </WindowHeader>
           <WindowContent className="window-content">
             <p className="window-content-p">Welcome to the DistroHopper Wheel of Fortune!
@@ -167,7 +158,7 @@ const Home = () => {
           )}
         </Window>
       </ThemeProvider>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -158,7 +158,7 @@ const Home = () => {
                     <p className="result-window-p">{`You won: ${result}`}</p>
                     <p className="result-window-p">{descriptions[result]}</p>
                     <br/>
-                    <p className="result-window-p-info">Here could be a little pixelart of each Distro, but I haven't found a nice collection of Linux Distro pixelarts! =(! So for now enjoy the little tux.</p>
+                    <p className="result-window-p-info">Here could be a little pixelart of each Distro, but I haven&apos;t found a nice collection of Linux Distro pixelarts! =(! So for now enjoy the little tux.</p>
                   </div>
                 </WindowContent>
               </Window>

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -1,18 +1,5 @@
 
 /* CSS IS MAKING ME GO INSANE */
-
-html, body, #root {
-  height: 100%;
-  margin: 0;
-  overflow: auto;
-}
-#root {
-  display: flex;
-  flex-direction: column;
-}
-.app-bar {
-  z-index: 1000;
-}
 .toolbar {
   justify-content: space-between;
   flex-wrap: wrap;
@@ -41,19 +28,11 @@ html, body, #root {
   overflow: auto;
 }
 .window {
-  flex: 1;
-  margin: 1rem;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  z-index: 1;
-  max-height: 80vh;
-  top: 2rem;
+  max-height: 85vh;
+  overflow: scroll; /* Wheel shouldnt leave it's container */
 }
 .window-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  overflow: hidden;
 }
 .window-content {
   flex: 1;

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -27,7 +27,8 @@
   overflow: auto;
 }
 .window {
-  max-height: 85vh;
+  margin-top: 0 !important;
+  max-height: 86vh;
   overflow: scroll; /* Wheel shouldnt leave it's container */
 }
 .window-header {

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -1,4 +1,3 @@
-
 /* CSS IS MAKING ME GO INSANE */
 .toolbar {
   justify-content: space-between;

--- a/src/styles/Wheel.css
+++ b/src/styles/Wheel.css
@@ -8,5 +8,6 @@
   
   .spin-button {
     margin-top: 1rem;
-    margin-bottom: 1rem; 
+    margin-bottom: 1rem;
+    overflow: hidden;
   }


### PR DESCRIPTION
A few minor changes that improve the UX. In addition, the behavior of overflows has been adjusted so that texts no longer leave their container

## Removed:
- unused imports, mostly the default import from 'react'.
- unused CSS rules

## Changed:
- Home.jsx: root  is now a react [Fragment](https://react.dev/reference/react/Fragment) <div></div> => <> </> b89493d6b2a108994bbe4e36a04b5a8a95e0320d 
- Some CSS rules handling overflow now correctly (hiding it). The window content is now scrollable when an overflow occurs.
- Adjusted window height from 80vh to 85vh (removed margin-top) so the button is visible without scrolling on 1080p.


![1080P](https://github.com/user-attachments/assets/d4e66d9a-3fe1-49b0-9aeb-d3bb7ac3b31a)
![Small](https://github.com/user-attachments/assets/5dd51219-9f3f-41b1-bef2-2d9d46b90b7d)
